### PR TITLE
feat: Implement bcrypt password hashing

### DIFF
--- a/src/lib/utils/password-utils.ts
+++ b/src/lib/utils/password-utils.ts
@@ -1,26 +1,47 @@
 import { createHash } from 'crypto';
+import bcrypt from 'bcrypt';
+
+// Salt rounds for bcrypt (higher is more secure but slower)
+const BCRYPT_SALT_ROUNDS = 10;
+// Prefix to identify bcrypt hashes
+const BCRYPT_PREFIX = 'bcrypt:';
 
 /**
- * Simple password hashing using SHA-256 with a salt
- * Note: In a production environment, a more secure method like bcrypt should be used
+ * Password hashing using bcrypt with backward compatibility
+ * for legacy SHA-256 hashes
  */
 export async function hashPassword(password: string): Promise<string> {
-  // Generate a random salt
-  const salt = Math.random().toString(36).substring(2, 15);
+  // Use bcrypt for all new passwords
+  const salt = await bcrypt.genSalt(BCRYPT_SALT_ROUNDS);
+  const hash = await bcrypt.hash(password, salt);
 
-  // Hash the password with the salt
-  const hash = createHash('sha256')
-    .update(password + salt)
-    .digest('hex');
-
-  // Return salt:hash
-  return `${salt}:${hash}`;
+  // Return with prefix to identify as bcrypt hash
+  return `${BCRYPT_PREFIX}${hash}`;
 }
 
 /**
  * Compares a plain text password with a stored hash
+ * Handles both bcrypt and legacy SHA-256 hashes
  */
 export async function comparePassword(password: string, storedHash: string): Promise<boolean> {
+  return storedHash.startsWith(BCRYPT_PREFIX)
+    ? await compareBcryptPassword(password, storedHash)
+    : compareLegacyPassword(password, storedHash);
+}
+
+async function compareBcryptPassword(password: string, storedHash: string) {
+  if (!storedHash.startsWith(BCRYPT_PREFIX)) {
+    console.warn('Bcrypt hash does not have expected prefix');
+  }
+  const hash = storedHash.substring(BCRYPT_PREFIX.length);
+  return await bcrypt.compare(password, hash);
+}
+
+/**
+ * Helper function to compare with legacy SHA-256 hashes
+ * @private
+ */
+function compareLegacyPassword(password: string, storedHash: string): boolean {
   const parts = storedHash.split(':');
   if (parts.length !== 2) {
     return false;


### PR DESCRIPTION
### Description

Replaces the previous SHA-256 password hashing utility with bcrypt, the industry standard for password hashing, while keeping backwards compatibility for existing hashes (by prefixing new hashes using `bcrypt:`).

### Key Changes

`password-utils.ts`

*   New password-protected pastes will now use bcrypt for hashing (using 10 salt rounds).
*   The `comparePassword` function can successfully verify passwords against both new bcrypt hashes (prefixed with \`bcrypt:\`) and existing legacy SHA-256 hashes.)

### How Has This Been Tested?

*   Created new pastes with passwords, verified they use bcrypt hashes (checked prefix).
*   Verified that comparison works correctly for newly created bcrypt hashes.
*   Verified that comparison still works for any existing legacy hashes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement *<- Arguably, security is an improvement*
- [ ] Code cleanup or refactor