### PR TITLE
style: Add top margin for 'Access Paste' button

### DIFF
--- a/src/components/paste/password-form.tsx
+++ b/src/components/paste/password-form.tsx
@@ -103,7 +103,7 @@ export function PasswordForm({ pasteId, onSuccess }: PasswordFormProps) {
               {error && <p className="text-destructive text-sm">{error}</p>}
             </div>
           </CardContent>
-          <CardFooter>
+          <CardFooter className={'mt-2'}>
             <Button type="submit" className="w-full" disabled={isSubmitting}>
               {isSubmitting ? (
                 <>


### PR DESCRIPTION
Adds a small top margin to te Access Paste button to improve visual spacing, since right now, there is NO space between them